### PR TITLE
Allow collapsing json output and fix bug with quotes within a value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ application/cache/*
 application/logs/*
 !application/logs/index.html
 !application/logs/.htaccess
+
+# Intellij IDEA
+.idea
+*.iml

--- a/application/views/csv2json_view.php
+++ b/application/views/csv2json_view.php
@@ -4,7 +4,7 @@
 			<p>Convert your CSV or TSV formatted data to JSON. Optionally transpose your data, or output an object instead of an array. Copy/paste or upload your Excel data to convert it to JSON.</p>
 		</div>
 	</div>
-	
+
 	<div class="row">
 		<div class="col-md-5 more-bottom-margin">
 			<div class="form-group">
@@ -40,7 +40,7 @@ Nine Miles from the White City, 2013, -
 				<i class="glyphicon glyphicon-remove"></i> Clear
 			</button>
 		</div>
-		
+
 		<div class="col-md-7 more-bottom-margin">
 			<div class="form-group">
 				<label>Options <small>Hover on option for help</small></label>
@@ -62,10 +62,14 @@ Nine Miles from the White City, 2013, -
 					<label class="inline" title="Transpose the data beforehand.">
 						<input type="checkbox" id="transpose" name="transpose" class="save" /> Transpose
 					</label>
-					&nbsp;
+					&nbsp;<label class="inline" title="Collapse.">
+						<input type="checkbox" id="collapse" name="collapse" class="save" /> Collapse
+					</label>
+					<span>&nbsp;</span>
 					<label class="inline">Output:</label>
 					<label class="radio-inline" title="Output an array of objects."><input type="radio" id="output-array" name="output" class="save" value="array" checked="checked" />Array</label>
 					<label class="radio-inline"  title="Output an object instead of an array. First column is used as hash key."><input type="radio" id="output-hash" name="output" class="save" value="hash" />Hash</label>
+
 				</div>
 			</div>
 			<div class="form-group code-group">

--- a/js/csvjson/csv2json.js
+++ b/js/csvjson/csv2json.js
@@ -9,19 +9,19 @@
 	 *  - separator: Optional. Character which acts as separator. If omitted,
 	 *               will attempt to detect comma (,), semi-colon (;) or tab (\t).
 	 *
-	 * Dependencies: 
+	 * Dependencies:
 	 *  - underscore (http://underscorejs.org/)
 	 *  - underscore.string (https://github.com/epeli/underscore.string)
 	 *
 	 * Copyright (c) 2014 Martin Drapeau
 	 *
 	 */
-	
+
 	var errorDetectingSeparator = "We could not detect the separator.",
 		errorEmpty = "Please upload a file or type in something.",
 		errorEmptyHeader = "Could not detect header. Ensure first row cotains your column headers.",
 		separators = [",", ";", "\t"];
-	
+
 	function detectSeparator(csv) {
 		var counts = {},
 			sepMax;
@@ -103,6 +103,7 @@
             } else {
 
                 // We found a non-quoted value.
+				// but escape any internal quotes
                 strMatchedValue = arrMatches[ 3 ];
 
             }
@@ -116,11 +117,11 @@
         // Return the parsed data.
         return( arrData );
     }
-	
+
 	function convert(csv, options) {
 		options || (options = {});
 		if (csv.length == 0) throw errorEmpty;
-		
+
 		var separator = options.separator || detectSeparator(csv);
 		if (!separator) throw errorDetectingSeparator;
 
@@ -134,13 +135,13 @@
 		keys = _.map(keys, function(key) {
 			return _(key).chain().trim().trim('"').value();
 		});
-		
+
 		var	json = options.hash ? {} : [];
 		for (var l = 0; l < a.length; l++) {
 			var row = {},
 				hashKey;
 			for (var i = 0; i < keys.length; i++) {
-				var value = _(a[l][i]).chain().trim().trim('"').value(),
+				var value = _(a[l][i]).chain().trim().value(),
 					number = value === "" ? NaN : value - 0;
 				if (options.hash && i == 0)
 					hashKey = value;
@@ -152,11 +153,11 @@
 			else
 				json.push(row);
 		}
-		
+
 		return json;
 	};
-	
+
 	this.CSVJSON || (this.CSVJSON = {});
 	this.CSVJSON.csv2json = convert;
-	
+
 }).call(this);

--- a/js/src/csv2json.js
+++ b/js/src/csv2json.js
@@ -4,7 +4,7 @@
  * Copyright (c) 2014 Martin Drapeau
  */
 APP.csv2json = function() {
-	
+
 	var uploadUrl = '/csv2json/upload',
   		sepMap = {
   			comma: ',',
@@ -15,25 +15,27 @@ APP.csv2json = function() {
   		$separator = $('select[name=separator]'),
   		$parseNumbers = $('input[type=checkbox][name=parseNumbers]'),
   		$transpose = $('input[type=checkbox][name=transpose]'),
+  		$collapse = $('input[type=checkbox][name=collapse]'),
   		$output = $('input[type=radio][name=output]'),
   		$csv = $('#csv'),
   		$json = $('#json'),
   		$clear = $('#clear, a.clear'),
   		$convert = $('#convert, a.convert');
-	
+
 	$convert.click(function(e) {
 		e.preventDefault();
-		
+
 		var csv = _.trim($csv.val()),
 			separator = $separator.find('option:selected').val(),
 			options = {
 				transpose: $transpose.is(':checked'),
+				collapse: $collapse.is(':checked'),
 				hash: $output.filter(':checked').val() == 'hash',
-				parseNumbers: $parseNumbers.is(':checked')
+				parseNumbers: $parseNumbers.is(':checked'),
 			},
 			json;
 		if (separator != 'auto') options.separator = sepMap[separator];
-		
+
 		try {
 			console.log(options);
 			json = CSVJSON.csv2json(csv, options);
@@ -41,11 +43,13 @@ APP.csv2json = function() {
 			APP.reportError($json, error);
 			return false;
 		}
-		
-		var result = JSON.stringify(json, null, 2);
+
+		var result = options.collapse
+			? JSON.stringify(json)
+			: JSON.stringify(json, null, 2);
 		$json.removeClass('error').val(result);
 	});
-	
+
 	APP.start({
 		$convert: $convert,
 		$clear: $clear,


### PR DESCRIPTION
Hi Martin,

Awesome tool! Love it! Had a bug though when I had quotes within a value, e.g. in the following csv data:
`
foo
bar "baz"
more foo
`

the json output would be:
[
  {
    "foo": "bar \"baz" // missing quote here
  },
  {
    "foo": "more foo"
  }
]

I removed the trim('"') on the value and tested with lots of inputs and it seems to work. You may have had a good reason for this - would like to know - but for my use cases this works.

I also needed collapsed output, so added an option for that, that just uses JSON.stringify(json).

Cheers,
Andre