### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-CSVJSON
-=======
+# CSVJSON
 
 www.csvjson.com are online formatting and conversion tools that I use as a developer.
+
 - [CSV to JSON](https://www.csvjson.com/csv2json): Convert CSV (Excel) to JSON format.
 - [JSON to CSV](https://www.csvjson.com/json2csv): Convert JSON to CSV format (Excel).
 - [SQL to JSON](https://www.csvjson.com/sql2json): Convert SQL (CREATE TABLE and INSERT INTO statements) to JSON format.
@@ -14,56 +14,52 @@ CSVJSON is built using PHP CodeIgniter, Bootstrap 3.0, Underscore, JSON, jsonlin
 
 Forking welcome: https://github.com/martindrapeau/csvjson-app
 
+## Installation
 
-Installation
-------------
+1. Clone and drop inside a folder under a virtual host using your favorite WAMP or LAMP stack.
+2. Create a `data` directory at the same level as `www`. Saved data for permalinks get stored there.
+3. Create file application/config/aws_s3.php and paste this into it:
 
-1.  Clone and drop inside a folder under a virtual host using your favorite WAMP or LAMP stack.
-2.  Create a `data` directory at the same level as `www`. Saved data for permalinks get stored there.
-3.  Create file application/config/aws_s3.php and paste this into it:
-```
-<?php  if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+```php
+if (!defined('BASEPATH')) exit('No direct script access allowed');
 $config['aws_s3'] = array('supported' => defined('AWS_S3_URL'));
 ```
 
 CodeIgniter's index.php will start everything. If you plan to deploy in a production environment, edit it and change this with your domain name:
-```
+
+```php
 if (strpos($_SERVER['SERVER_NAME'], "csvjson.com") !== FALSE) {
-	define('ENVIRONMENT', 'production');
+    define('ENVIRONMENT', 'production');
 } else {
-	define('ENVIRONMENT', 'development');
+    define('ENVIRONMENT', 'development');
 }
 ```
 
 If you use Apache, CSVJSON comes with a .htaccess all ready to go. Blocks remote access of sensible files like this README, .git, etc...
 
-Extending
-=========
+## Extending
 
 To add a new tool, best to look at an existing example. For example csv2json. Follow these steps:
 
-1.  Create a controller (under application/controllers/). Must inherit MY_Controller.
-2.  Create a view (under application/views/).
-3.  Create the conversion JavaScript file (under js/src/csvjson). This file will contain your new conversion function on the CSVJSON global.
-3.  Create the UI JavaScript file (under js/src/). This will drive the UI, and call your conversion function to do the work.
-4.  Create a CSS file (under css) or you can put your CSS directly inside css/main.css.
-5.  Update `$config['assets']` located in the `application/config/assets.php` file and add reference to your JavaScript and optionally CSS files.
+1. Create a controller (under application/controllers/). Must inherit MY_Controller.
+2. Create a view (under application/views/).
+3. Create the conversion JavaScript file (under js/src/csvjson). This file will contain your new conversion function on the CSVJSON global.
+4. Create the UI JavaScript file (under js/src/). This will drive the UI, and call your conversion function to do the work.
+5. Create a CSS file (under css) or you can put your CSS directly inside css/main.css.
+6. Update `$config['assets']` located in the `application/config/assets.php` file and add reference to your JavaScript and optionally CSS files.
 
 You are then ready to code. In development (ENVIRONMENT=development), your JavaScript and CSS files get loaded.
 
+## Deploy for production
 
-Deploy for production
----------------------
+To deploy for production, you must perform a build. Bundles are compiled in the Build controller (`application/controllers/build.php`). To perform a build, simply call the controller. JavaScript bundles get built - minified and concatenated.
 
-To deploy for production, you must perform a build. Bundles are compiled in the Build controller (`application/controllers/build.php`). To perform a build, simply call the controller. JavaScript bundles get built - minified and concatenated. For example, if you are developing under `localhost`, you would type in a browser
-```
-http://localhost/build
-```
-Built assets must then be committed to git. In production, built assets are loaded.
+For example, if you are developing under `localhost`, you would type in a browser http://localhost/build
 
+Built assets must then be committed to Git. In production, built assets are loaded.
 
-Directory Structure
--------------------
+## Directory Structure
+
 ```
 --application
   --config
@@ -76,16 +72,17 @@ Directory Structure
   --src
 --css
 ```
+
 Directories `application` and `system` are those defined by CodeIgniter. Assets are located under `js` and `css` folders. 3rd party JavaScript libraries are under `js/3rd` and application source code (the stuff you write) is under `js/src`. Bundled/minified JavaScript files are directly under `js`.
 
+## AWS S3
 
-AWS S3
-------
 Saved sessions are stored in Amazon Web Services Simple Storage.
-The following config file must exist, but never be committed and versioned in git 
+The following config file must exist, but never be committed and versioned in Git 
 application/config/aws_s3.php
-```
-<?php  if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+```php
+if (!defined('BASEPATH')) exit('No direct script access allowed');
 if (defined('CURL_SSLVERSION_TLSv1')) {
   define('AWS_S3_KEY', 'XXXX');
   define('AWS_S3_SECRET', 'XXXX');
@@ -96,15 +93,13 @@ if (defined('CURL_SSLVERSION_TLSv1')) {
 $config['aws_s3'] = array('supported' => defined('AWS_S3_URL'));
 ```
 
-FAQ
-===
+## FAQ
 
 Q: What if I fund a bug or would like to propose an enhancement? <br/>
 A: Report it via [GitHub issues](https://github.com/martindrapeau/csvjson-app/issues).
 
 Q: What performs minification? <br/>
-A: JavaScript minification is done with a PHP implmentation of Douglas Crockford's JSMin. See `application/libraries/jsmin.php` for details. CSS minification comes from http://code.google.com/p/minify/. See `application/libraries/cssmin.php`.
+A: JavaScript minification is done with a PHP implementation of Douglas Crockford's JSMin. See `application/libraries/jsmin.php` for details. CSS minification comes from http://code.google.com/p/minify/. See `application/libraries/cssmin.php`.
 
 Q: Does bundling and minification support CSS pre-processing like SASS, LESS or Stylus? <br/>
 A: No. Feel free to fork and add it. Would be nice.
-

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ www.csvjson.com are online formatting and conversion tools that I use as a devel
 - [JSON to CSV](https://www.csvjson.com/json2csv): Convert JSON to CSV format (Excel).
 - [SQL to JSON](https://www.csvjson.com/sql2json): Convert SQL (CREATE TABLE and INSERT INTO statements) to JSON format.
 - [JSON Validator](https://csvjson.com/json_validator): Cerifies that your JavaScript Object Notation adheres to the JSON specification.
-- [JSON Beautifier](https://www.csvjson.com/json_beautifier): Format and make beautiful JSON. Convert it to Javascript code (drop quotes on keys).
+- [JSON Beautifier](https://www.csvjson.com/json_beautifier): Format and make beautiful JSON. Convert it to JavaScript code (drop quotes on keys).
 - [Data Janitor](https://www.csvjson.com/datajanitor): Online tool for Excel and Google Sheets data cleaning and transformation using user-written JavaScript.
 - More to come...
 
@@ -44,18 +44,18 @@ To add a new tool, best to look at an existing example. For example csv2json. Fo
 
 1.  Create a controller (under application/controllers/). Must inherit MY_Controller.
 2.  Create a view (under application/views/).
-3.  Create the conversion Javascript file (under js/src/csvjson). This file will contain your new conversion function on the CSVJSON global.
-3.  Create the UI Javascript file (under js/src/). This will drive the UI, and call your conversion function to do the work.
+3.  Create the conversion JavaScript file (under js/src/csvjson). This file will contain your new conversion function on the CSVJSON global.
+3.  Create the UI JavaScript file (under js/src/). This will drive the UI, and call your conversion function to do the work.
 4.  Create a CSS file (under css) or you can put your CSS directly inside css/main.css.
-5.  Update `$config['assets']` located in the `application/config/assets.php` file and add reference to your Javascript and optionally CSS files.
+5.  Update `$config['assets']` located in the `application/config/assets.php` file and add reference to your JavaScript and optionally CSS files.
 
-You are then ready to code. In development (ENVIRONMENT=development), your Javascript and CSS files get loaded.
+You are then ready to code. In development (ENVIRONMENT=development), your JavaScript and CSS files get loaded.
 
 
 Deploy for production
 ---------------------
 
-To deploy for production, you must perform a build. Bundles are compiled in the Build controller (`application/controllers/build.php`). To perform a build, simply call the controller. Javascript bundles get built - minified and concatenated. For example, if you are developing under `localhost`, you would type in a browser
+To deploy for production, you must perform a build. Bundles are compiled in the Build controller (`application/controllers/build.php`). To perform a build, simply call the controller. JavaScript bundles get built - minified and concatenated. For example, if you are developing under `localhost`, you would type in a browser
 ```
 http://localhost/build
 ```
@@ -76,7 +76,7 @@ Directory Structure
   --src
 --css
 ```
-Directories `application` and `system` are those defined by CodeIgniter. Assets are located under `js` and `css` folders. 3rd party Javascript libraries are under `js/3rd` and application source code (the stuff you write) is under `js/src`. Bundled/minified Javascript files are directly under `js`.
+Directories `application` and `system` are those defined by CodeIgniter. Assets are located under `js` and `css` folders. 3rd party JavaScript libraries are under `js/3rd` and application source code (the stuff you write) is under `js/src`. Bundled/minified JavaScript files are directly under `js`.
 
 
 AWS S3
@@ -100,10 +100,10 @@ FAQ
 ===
 
 Q: What if I fund a bug or would like to propose an enhancement? <br/>
-A: Report it via [Github issues](https://github.com/martindrapeau/csvjson-app/issues).
+A: Report it via [GitHub issues](https://github.com/martindrapeau/csvjson-app/issues).
 
 Q: What performs minification? <br/>
-A: Javascript minification is done with a PHP implmentation of Douglas Crockford's JSMin. See `application/libraries/jsmin.php` for details. CSS minification comes from http://code.google.com/p/minify/. See `application/libraries/cssmin.php`.
+A: JavaScript minification is done with a PHP implmentation of Douglas Crockford's JSMin. See `application/libraries/jsmin.php` for details. CSS minification comes from http://code.google.com/p/minify/. See `application/libraries/cssmin.php`.
 
 Q: Does bundling and minification support CSS pre-processing like SASS, LESS or Stylus? <br/>
 A: No. Feel free to fork and add it. Would be nice.

--- a/application/controllers/build.php
+++ b/application/controllers/build.php
@@ -1,7 +1,7 @@
 <?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 
 /*
- * Javascript and CSS Bundling and Minification.
+ * JavaScript and CSS Bundling and Minification.
  *
  * Copyright (c) 2014 Martin Drapeau
  *
@@ -20,7 +20,7 @@ class Build extends CI_Controller {
 	}
 	
 	public function index() {
-		echo "Minifying Javascript Files...<br/>";
+		echo "Minifying JavaScript Files...<br/>";
 	
 		// Increase the version number by 0.001
 		$old_version = file_get_contents(VERSION_FILE);

--- a/application/controllers/csvjson.php
+++ b/application/controllers/csvjson.php
@@ -14,7 +14,7 @@ class Csvjson extends MY_Controller {
 		
 		$this->page = 'home';
 		$this->title = 'CSVJSON';
-		$this->description = 'Online Conversion Tools for Developers. CSV, JSON, SQL and Javascript. Sponsored by Flatfile.';
+		$this->description = 'Online Conversion Tools for Developers. CSV, JSON, SQL and JavaScript. Sponsored by Flatfile.';
 		$this->view = 'home_view';
 		$this->showSave = false;
 	}

--- a/application/libraries/jsmin.php
+++ b/application/libraries/jsmin.php
@@ -66,9 +66,9 @@ class JSMin {
     protected $output      = '';
     
     /**
-     * Minify Javascript
+     * Minify JavaScript
      *
-     * @param string $js Javascript to be minified
+     * @param string $js JavaScript to be minified
      * @return string
      */
     public static function minify($js)

--- a/application/views/feedback.php
+++ b/application/views/feedback.php
@@ -1,6 +1,6 @@
 <h4>Feedback</h4>
 <p>
-	<a href="https://github.com/martindrapeau/csvjson-app">Code available on Github.</a>
+	<a href="https://github.com/martindrapeau/csvjson-app">Code available on GitHub.</a>
 	Report bugs or ask for improvements through
-	<a href="https://github.com/martindrapeau/csvjson-app/issues">Github issues</a>.
+	<a href="https://github.com/martindrapeau/csvjson-app/issues">GitHub issues</a>.
 </p>

--- a/application/views/home_view.php
+++ b/application/views/home_view.php
@@ -73,7 +73,7 @@
 					CSVJSON is a do-it-myself and more permanent solution. Its best feature? You can save your session for later, and share it with a co-worker.
 				</p>
 				<p>
-					If you find bugs or would like an improvement, please leave a comment below or open an issue on <a href="https://github.com/martindrapeau/csvjson-app/issues" target="_blank">Github</a>.
+					If you find bugs or would like an improvement, please leave a comment below or open an issue on <a href="https://github.com/martindrapeau/csvjson-app/issues" target="_blank">GitHub</a>.
 				</p>
 				<p>
 					I hope it can be useful to you. Happy conversions!
@@ -224,7 +224,7 @@
 			</p>
 			<h4>2016-03-19</h4>
 			<p>
-				Make the Github repository public again. Re-opened to community.
+				Make the GitHub repository public again. Re-opened to community.
 			</p>
 			<h4>2015-11-25</h4>
 			<p>
@@ -237,9 +237,9 @@
 			<br/>
 			<h3>Bugs and Feature Requests</h3>
 			<p>
-				<a href="https://github.com/martindrapeau/csvjson-app">Code available on Github.</a>
+				<a href="https://github.com/martindrapeau/csvjson-app">Code available on GitHub.</a>
 				Report bugs or ask for improvements through
-				<a href="https://github.com/martindrapeau/csvjson-app/issues">Github issues</a>.
+				<a href="https://github.com/martindrapeau/csvjson-app/issues">GitHub issues</a>.
 			</p>
 			<br/>
 		</div>

--- a/application/views/json2csv_view.php
+++ b/application/views/json2csv_view.php
@@ -129,7 +129,7 @@
       <h4>About JSON to CSV</h4>
       <ul>
         <li>
-          JSON to CSV will convert an array of objects into a table. By default, nested arrays or objects will simply be stringified and copied as is in each cell. Alternatively, you can flatten nested arrays of objects as requested by <a href="https://github.com/rogeriomarques" target="_blank">Rogerio Marques</a> in <a href="https://github.com/martindrapeau/csvjson-app/issues/3" target="_blank">Github issue #3</a>.
+          JSON to CSV will convert an array of objects into a table. By default, nested arrays or objects will simply be stringified and copied as is in each cell. Alternatively, you can flatten nested arrays of objects as requested by <a href="https://github.com/rogeriomarques" target="_blank">Rogerio Marques</a> in <a href="https://github.com/martindrapeau/csvjson-app/issues/3" target="_blank">GitHub issue #3</a>.
         </li>
       </ul>
       <h4>CSVJSON format variant</h4>

--- a/application/views/json_beautifier_view.php
+++ b/application/views/json_beautifier_view.php
@@ -36,7 +36,7 @@
 				<label>Options <small>Hover on option for help</small></label>
 				<div class="form-control">
 					<label class="inline">No quotes:</label>
-					<label class="inline" title="JSON wraps keys with double quotes by default. Javascript doesn't need them though. Check this box to drop them. Will make for invalid JSON but valid Javascript.">
+					<label class="inline" title="JSON wraps keys with double quotes by default. JavaScript doesn't need them though. Check this box to drop them. Will make for invalid JSON but valid JavaScript.">
 						<input type="checkbox" id="drop-quotes-on-keys" name="drop-quotes-on-keys" class="save" /> on keys
 					</label>
 					<label class="inline" title="Check this box to parse number values and drop quotes around them.">
@@ -94,21 +94,21 @@
 			<ul>
 				<li>JSON stands for <strong>JavaScript Object Notation</strong>. It is a lightweight data-interchange format and fully described on <a href="http://www.json.org" target="_blank">www.json.org</a>.</li>
 				<li>
-					JSON is based on Javascript but the format is stricter. JSON requires double quotes around keys whereas Javascript does not. For example, this is valid Javascript:<br/>
+					JSON is based on JavaScript but the format is stricter. JSON requires double quotes around keys whereas JavaScript does not. For example, this is valid JavaScript:<br/>
 					<pre>{pi: 3.14159265359, e: 2.7182818284, prime: [2, 3, 5, 7, 11, 13, 17, 19]}</pre>
 					However the above is not valid JSON. Double quotes must be placed around pi, e and prime.
 					<pre>{"pi": 3.14159265359, "e": 2.7182818284, "prime": [2, 3, 5, 7, 11, 13, 17, 19]}</pre>
-					CSVJSON's JSON Beautifier has a toggle to drop quotes on keys. It can do so if Javascript allows it. For example, we cannot drop quotes around key <code>"1+6"</code>.
+					CSVJSON's JSON Beautifier has a toggle to drop quotes on keys. It can do so if JavaScript allows it. For example, we cannot drop quotes around key <code>"1+6"</code>.
 					CSVJSON also has a toggle to use single quotes to wrap keys and values.
 				</li>
 				<li>Modern browsers have a built-in global object <code>JSON</code> with encoding and decoding functions. These are:
 					<ul>
-						<li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify" target="_blank">JSON.stringify</a> to encode a Javascript object into a JSON string; and</li>
-						<li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse" target="_blank">JSON.parse</a> to parse a JSON string and convert it to a Javascript object.</li>
+						<li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify" target="_blank">JSON.stringify</a> to encode a JavaScript object into a JSON string; and</li>
+						<li><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse" target="_blank">JSON.parse</a> to parse a JSON string and convert it to a JavaScript object.</li>
 					</ul>
 					To support older browsers, use <a href="https://github.com/douglascrockford/JSON-js" target="_blank">JSON2</a> written by Douglas Crockford as polyfill.
 				</li>
-				<li>CSVJON uses a <a href="https://github.com/martindrapeau/csvjson-app/blob/master/js/csvjson/json2-mod.js" target="_blank">modified version of JSON2</a> which adds formatting options to drop quotes on keys, and sepcify the quote type. Anyone is free to use and extend it by forking the <a href="https://github.com/martindrapeau/csvjson-app" target="_blank">CSVJSON Github repo</a>.</li>
+				<li>CSVJON uses a <a href="https://github.com/martindrapeau/csvjson-app/blob/master/js/csvjson/json2-mod.js" target="_blank">modified version of JSON2</a> which adds formatting options to drop quotes on keys, and sepcify the quote type. Anyone is free to use and extend it by forking the <a href="https://github.com/martindrapeau/csvjson-app" target="_blank">CSVJSON GitHub repo</a>.</li>
 			</ul>
 			<br/>
 			<h4>Change Log</h4>

--- a/application/views/page.php
+++ b/application/views/page.php
@@ -119,7 +119,7 @@
 				<p>
 					&copy; 2014-2019 <a href="https://medium.com/@martindrapeau">Martin Drapeau</a> &nbsp;
 					<a href="https://github.com/martindrapeau/csvjson-app/issues">Report an issue</a> &nbsp;
-					<a href="https://github.com/martindrapeau/csvjson-app">Code available on Github</a>
+					<a href="https://github.com/martindrapeau/csvjson-app">Code available on GitHub</a>
 				</p>
 			</div>
 		</footer>

--- a/application/views/sql2json_view.php
+++ b/application/views/sql2json_view.php
@@ -1,8 +1,8 @@
 <div class="container-fluid">
 	<div class="row">
 		<div class="description col-md-12">
-			<h1 class="discrete">Convert your SQL table or database export to JSON or Javascript.</h1>
-			<p>1) Copy/paste or upload your SQL export to convert it. 2) Convert to JSON or Javascript (one variable is created per table). 3) Copy and paste back to your computer. 4) Save your result for later or for sharing.</p>
+			<h1 class="discrete">Convert your SQL table or database export to JSON or JavaScript.</h1>
+			<p>1) Copy/paste or upload your SQL export to convert it. 2) Convert to JSON or JavaScript (one variable is created per table). 3) Copy and paste back to your computer. 4) Save your result for later or for sharing.</p>
 		</div>
 	</div>
 	
@@ -62,7 +62,7 @@ INSERT INTO `continents` VALUES ('??', NULL);
 				<label>Output format</label>
 				<div class="form-control options">
 					<label class="radio-inline"><input type="radio" id="json" name="format" class="save" value="json" checked="checked" />JSON</label>
-					<label class="radio-inline"><input type="radio" id="javascript" name="format" class="save" value="javascript" />Javascript</label>
+					<label class="radio-inline"><input type="radio" id="javascript" name="format" class="save" value="javascript" />JavaScript</label>
 					&nbsp;
 					<label class="inline" title="Minify or compact result by removing spaces and new lines.">
 						<input type="checkbox" id="minify" name="minify" class="save" /> Minify

--- a/js/csvjson/json2-mod.js
+++ b/js/csvjson/json2-mod.js
@@ -49,14 +49,14 @@
                         Specify either `double` for " or `single` for '.
                         Defaults to double quote however you can overwrite with
                         a single quote. Do note that the output will not be valid
-                        JSON, but it will be valid Javascript.
+                        JSON, but it will be valid JavaScript.
 
             quoteType
                         an optional parameter to specify the quote character.
                         Use either `double` or `single`.
                         Defaults to double quote " however you can overwrite with
                         a single quote '. Do note that the output will not be valid
-                        JSON is you use `single`, but it will be valid Javascript.
+                        JSON is you use `single`, but it will be valid JavaScript.
       
             This method produces a JSON text from a JavaScript value.
 
@@ -251,7 +251,7 @@
         }) + surroundingQuote : surroundingQuote + string + surroundingQuote;
     }
   
-// Conditionally quote a key if it cannot be a Javascript variable
+// Conditionally quote a key if it cannot be a JavaScript variable
   function condQuoteKey(string, quoteType) {
     return keyable.test(string) ? string : quote(string, quoteType);
   }

--- a/js/csvjson/json2csv.js
+++ b/js/csvjson/json2csv.js
@@ -19,7 +19,7 @@
 
 	var errorMissingSeparator = 'Missing separator option.',
 		  errorEmpty = 'JSON is empty.',
-		  errorEmptyHeader = 'Could not detect header. Ensure first row cotains your column headers.',
+		  errorEmptyHeader = 'Could not detect header. Ensure first row contains your column headers.',
 		  errorNotAnArray = 'Your JSON must be an array or an object.',
 		  errorItemNotAnObject = 'Item in array is not an object: {0}';
 

--- a/js/csvjson/json_beautifier.js
+++ b/js/csvjson/json_beautifier.js
@@ -8,11 +8,11 @@
    * Available options:
    *  - space: The number of spaces to indent. Default is 2.
    *  - quoteType: You can change double quotes to single quotes (') if you
-   *           like to. Will make for invalid JSON but valid Javascript.
+   *           like to. Will make for invalid JSON but valid JavaScript.
    *           Default is (").
    *  - dropQuotesOnKeys: JSON wraps keys with double quotes by default.
-   *           Javascript doesn't need them though. Set to true to drop them.
-   *           Will make for invalid JSON but valid Javascript. Default is false.
+   *           JavaScript doesn't need them though. Set to true to drop them.
+   *           Will make for invalid JSON but valid JavaScript. Default is false.
    *  - dropQuotesOnNumbers: Set to true to parse number values and drop quotes
    *           around them. Default is false.
    *  - inlineShortArrays: Set to true to collpase arrays inline if less than 80

--- a/js/src/json_beautifier.js
+++ b/js/src/json_beautifier.js
@@ -62,7 +62,7 @@
     }
     
     $result.removeClass('error').val(result).change();
-    if (options.dropQuotesOnKeys || options.quoteType === 'single') $resultNote.text('Invalid JSON, but valid Javascript');
+    if (options.dropQuotesOnKeys || options.quoteType === 'single') $resultNote.text('Invalid JSON, but valid JavaScript');
   });
 
   

--- a/js/src/main.js
+++ b/js/src/main.js
@@ -276,8 +276,8 @@ $(document).ready(function() {
       var $issue = $('a#issue'),
           template = _.template([
             '<p>1. Save your test case (click on <span class="bg-red"><i class="glyphicon glyphicon-link"></i> Save</span> in navbar). Copy the URL to the clipboard.</p>',
-            '<p>2. <a href="https://github.com/martindrapeau/csvjson-app/issues" target="_blank">Consult issues on Github.</a> If you find an existing issue matching yours, please comment and paste the URL of your test case.</p>',
-            '<p>3. If you do not find an existing issue, create one by clicking on this button: <a id="github-issue" class="btn btn-xs btn-primary" href="https://github.com/martindrapeau/csvjson-app/issues/new?body=<%=encodeURIComponent(url)%>" target="_blank">Create an issue in Github</a></p>'
+            '<p>2. <a href="https://github.com/martindrapeau/csvjson-app/issues" target="_blank">Consult issues on GitHub.</a> If you find an existing issue matching yours, please comment and paste the URL of your test case.</p>',
+            '<p>3. If you do not find an existing issue, create one by clicking on this button: <a id="github-issue" class="btn btn-xs btn-primary" href="https://github.com/martindrapeau/csvjson-app/issues/new?body=<%=encodeURIComponent(url)%>" target="_blank">Create an issue in GitHub</a></p>'
           ].join(' '));
       $issue.click(function(e) {
         e.preventDefault();


### PR DESCRIPTION
A bunch of typo fixes, e.g.

`Javascript` -> `JavaScript`
`Github` -> `GitHub`